### PR TITLE
Fix 1x2-3.5MM terminal block hole pitch to be within manufacture spec

### DIFF
--- a/adafruit.lbr
+++ b/adafruit.lbr
@@ -8311,8 +8311,8 @@ type 0309, grid 2.5 mm</description>
 <wire x1="3.6" y1="-2.2" x2="3.6" y2="3.4" width="0.127" layer="21"/>
 <wire x1="3.6" y1="3.4" x2="-3.4" y2="3.4" width="0.127" layer="21"/>
 <wire x1="-3.4" y1="-2.2" x2="3.6" y2="-2.2" width="0.127" layer="21"/>
-<pad name="1" x="1.8" y="0" drill="1" diameter="2.1844"/>
-<pad name="2" x="-1.7" y="0" drill="1" diameter="2.1844"/>
+<pad name="1" x="1.8" y="0" drill="1.2" diameter="2.54"/>
+<pad name="2" x="-1.7" y="0" drill="1.2" diameter="2.54"/>
 <text x="3" y="5" size="1.27" layer="25" rot="R180">&gt;NAME</text>
 </package>
 <package name="UMAX10">


### PR DESCRIPTION
I used the 1x2-3.5MM in a project and when I got my PCB, the terminal blocks did not fit. After investigating, I found that the dimensional drawing from TE states they recommend a 1.2 - 1.4mm hole, but the eagle part uses a 1mm hole. The dimensional drawing says the pins are "0.9 typ", so perhaps I just got an atypical batch, but I think the hole should be within their spec to avoid this in the future.

This pull request changes the hole to 1.2mm and also increases the pad size as to not affect any electrical characteristics.

Dimensional drawing can be found here: http://www.te.com/catalog/pn/en/1776275-2
