### PR TITLE
Removed 'P$' prefix on pins of FGPMMOPA6

### DIFF
--- a/adafruit.lbr
+++ b/adafruit.lbr
@@ -25322,26 +25322,26 @@ diameter 2 mm, horizontal, grid 10.16 mm</description>
 <wire x1="8" y1="8" x2="8" y2="7.5" width="0.127" layer="21"/>
 <circle x="0.5" y="0.85" radius="0.5" width="0.8128" layer="51"/>
 <circle x="-9.1" y="8.4" radius="0.3162" width="0.8128" layer="21"/>
-<smd name="P$1" x="-7.5" y="6.75" dx="2" dy="1" layer="1"/>
-<smd name="P$2" x="-7.5" y="5.25" dx="2" dy="1" layer="1"/>
-<smd name="P$3" x="-7.5" y="3.75" dx="2" dy="1" layer="1"/>
-<smd name="P$4" x="-7.5" y="2.25" dx="2" dy="1" layer="1"/>
-<smd name="P$5" x="-7.5" y="0.75" dx="2" dy="1" layer="1"/>
-<smd name="P$6" x="-7.5" y="-0.75" dx="2" dy="1" layer="1"/>
-<smd name="P$7" x="-7.5" y="-2.25" dx="2" dy="1" layer="1"/>
-<smd name="P$8" x="-7.5" y="-3.75" dx="2" dy="1" layer="1"/>
-<smd name="P$9" x="-7.5" y="-5.25" dx="2" dy="1" layer="1"/>
-<smd name="P$10" x="-7.5" y="-6.75" dx="2" dy="1" layer="1"/>
-<smd name="P$11" x="7.5" y="-6.75" dx="2" dy="1" layer="1" rot="R180"/>
-<smd name="P$12" x="7.5" y="-5.25" dx="2" dy="1" layer="1" rot="R180"/>
-<smd name="P$13" x="7.5" y="-3.75" dx="2" dy="1" layer="1" rot="R180"/>
-<smd name="P$14" x="7.5" y="-2.25" dx="2" dy="1" layer="1" rot="R180"/>
-<smd name="P$15" x="7.5" y="-0.75" dx="2" dy="1" layer="1" rot="R180"/>
-<smd name="P$16" x="7.5" y="0.75" dx="2" dy="1" layer="1" rot="R180"/>
-<smd name="P$17" x="7.5" y="2.25" dx="2" dy="1" layer="1" rot="R180"/>
-<smd name="P$18" x="7.5" y="3.75" dx="2" dy="1" layer="1" rot="R180"/>
-<smd name="P$19" x="7.5" y="5.25" dx="2" dy="1" layer="1" rot="R180"/>
-<smd name="P$20" x="7.5" y="6.75" dx="2" dy="1" layer="1" rot="R180"/>
+<smd name="1" x="-7.5" y="6.75" dx="2" dy="1" layer="1"/>
+<smd name="2" x="-7.5" y="5.25" dx="2" dy="1" layer="1"/>
+<smd name="3" x="-7.5" y="3.75" dx="2" dy="1" layer="1"/>
+<smd name="4" x="-7.5" y="2.25" dx="2" dy="1" layer="1"/>
+<smd name="5" x="-7.5" y="0.75" dx="2" dy="1" layer="1"/>
+<smd name="6" x="-7.5" y="-0.75" dx="2" dy="1" layer="1"/>
+<smd name="7" x="-7.5" y="-2.25" dx="2" dy="1" layer="1"/>
+<smd name="8" x="-7.5" y="-3.75" dx="2" dy="1" layer="1"/>
+<smd name="9" x="-7.5" y="-5.25" dx="2" dy="1" layer="1"/>
+<smd name="10" x="-7.5" y="-6.75" dx="2" dy="1" layer="1"/>
+<smd name="11" x="7.5" y="-6.75" dx="2" dy="1" layer="1" rot="R180"/>
+<smd name="12" x="7.5" y="-5.25" dx="2" dy="1" layer="1" rot="R180"/>
+<smd name="13" x="7.5" y="-3.75" dx="2" dy="1" layer="1" rot="R180"/>
+<smd name="14" x="7.5" y="-2.25" dx="2" dy="1" layer="1" rot="R180"/>
+<smd name="15" x="7.5" y="-0.75" dx="2" dy="1" layer="1" rot="R180"/>
+<smd name="16" x="7.5" y="0.75" dx="2" dy="1" layer="1" rot="R180"/>
+<smd name="17" x="7.5" y="2.25" dx="2" dy="1" layer="1" rot="R180"/>
+<smd name="18" x="7.5" y="3.75" dx="2" dy="1" layer="1" rot="R180"/>
+<smd name="19" x="7.5" y="5.25" dx="2" dy="1" layer="1" rot="R180"/>
+<smd name="20" x="7.5" y="6.75" dx="2" dy="1" layer="1" rot="R180"/>
 <text x="-8" y="8.5" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
 <text x="-8" y="-9.5" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
 <hole x="0.5" y="0.85" drill="3"/>
@@ -53465,26 +53465,26 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/21952a.pdf</description>
 <devices>
 <device name="" package="FGPMMOPA6H">
 <connects>
-<connect gate="G$1" pin="1PPS" pad="P$13"/>
-<connect gate="G$1" pin="3D-FIX" pad="P$5"/>
-<connect gate="G$1" pin="EX_ANT" pad="P$11"/>
-<connect gate="G$1" pin="GND@1" pad="P$3"/>
-<connect gate="G$1" pin="GND@2" pad="P$8"/>
-<connect gate="G$1" pin="GND@3" pad="P$12"/>
-<connect gate="G$1" pin="GND@4" pad="P$19"/>
-<connect gate="G$1" pin="NC@1" pad="P$6"/>
-<connect gate="G$1" pin="NC@2" pad="P$7"/>
-<connect gate="G$1" pin="NC@3" pad="P$15"/>
-<connect gate="G$1" pin="NC@4" pad="P$16"/>
-<connect gate="G$1" pin="NC@5" pad="P$17"/>
-<connect gate="G$1" pin="NC@6" pad="P$18"/>
-<connect gate="G$1" pin="NC@7" pad="P$20"/>
-<connect gate="G$1" pin="NRESET" pad="P$2"/>
-<connect gate="G$1" pin="RTCM" pad="P$14"/>
-<connect gate="G$1" pin="RX" pad="P$10"/>
-<connect gate="G$1" pin="TX" pad="P$9"/>
-<connect gate="G$1" pin="VBACKUP" pad="P$4"/>
-<connect gate="G$1" pin="VCC" pad="P$1"/>
+<connect gate="G$1" pin="1PPS" pad="13"/>
+<connect gate="G$1" pin="3D-FIX" pad="5"/>
+<connect gate="G$1" pin="EX_ANT" pad="11"/>
+<connect gate="G$1" pin="GND@1" pad="3"/>
+<connect gate="G$1" pin="GND@2" pad="8"/>
+<connect gate="G$1" pin="GND@3" pad="12"/>
+<connect gate="G$1" pin="GND@4" pad="19"/>
+<connect gate="G$1" pin="NC@1" pad="6"/>
+<connect gate="G$1" pin="NC@2" pad="7"/>
+<connect gate="G$1" pin="NC@3" pad="15"/>
+<connect gate="G$1" pin="NC@4" pad="16"/>
+<connect gate="G$1" pin="NC@5" pad="17"/>
+<connect gate="G$1" pin="NC@6" pad="18"/>
+<connect gate="G$1" pin="NC@7" pad="20"/>
+<connect gate="G$1" pin="NRESET" pad="2"/>
+<connect gate="G$1" pin="RTCM" pad="14"/>
+<connect gate="G$1" pin="RX" pad="10"/>
+<connect gate="G$1" pin="TX" pad="9"/>
+<connect gate="G$1" pin="VBACKUP" pad="4"/>
+<connect gate="G$1" pin="VCC" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>


### PR DESCRIPTION
Default eagle pins prefix of 'P$' clutters the schematic so it's a good
idea to remove it.