### PR TITLE
Update connection of WS2812B-Mini pinout

### DIFF
--- a/adafruit.lbr
+++ b/adafruit.lbr
@@ -55194,10 +55194,10 @@ AT42QT1070 in standalone mode has 5 inputs (guard + 4 key) and open drain output
 </device>
 <device name="3535" package="LED3535">
 <connects>
-<connect gate="G$1" pin="DI" pad="1"/>
-<connect gate="G$1" pin="DO" pad="3"/>
-<connect gate="G$1" pin="GND" pad="4"/>
-<connect gate="G$1" pin="VDD" pad="2"/>
+<connect gate="G$1" pin="DI" pad="4"/>
+<connect gate="G$1" pin="DO" pad="2"/>
+<connect gate="G$1" pin="GND" pad="3"/>
+<connect gate="G$1" pin="VDD" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>


### PR DESCRIPTION
Issue #42 reported how the 3535 package was misrouted.

This reconnects the pads based on the datasheet for WS2812B-Mini.